### PR TITLE
Fixes to delay, score, tag and logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,6 @@
             <video id="video" class="camera-background-feed" autoplay playsinline muted></video>
         </div>
         <canvas id="landmarks" class="landmark-canvas"></canvas>
-        <img src="public/assets/umain_logotype_black.png" alt="logotype" class="img-logo" style="top: 20px; right: 20px; max-width: 20vw; max-height: 10vh;">
         <img src="public/assets/arrow_down_JIN.png" alt="logotype" class="img-logo" style="top: 20px; left: 20px;">
         <img src="public/assets/arrow_up_JIN.png" alt="logotype" class="img-logo" style="bottom: 20px; right: 20px;">
         <!-- Single-player overlays (default) -->

--- a/js/main.js
+++ b/js/main.js
@@ -352,7 +352,7 @@ function render() {
         const scoreArg2 = gameMode === 'multi' ? finalScore2 : null;
         const result = renderGameOver(overlay, g1, g2, c1, c2, finalScore1, scoreArg2);
         const idle = Date.now() - gameStartTime > 60000; // auto-reset after 60s of inactivity
-        const bufferTime = Date.now() - gameStartTime < 3000; // ignore inputs for first 3 seconds to prevent accidental skips
+        const bufferTime = Date.now() - gameStartTime < 5000; // ignore inputs for first 5 seconds to prevent accidental skips
 
         if (overlay.querySelector('.scoreboard__playagain')) {
             overlay.querySelector('.scoreboard__playagain').style.visibility = bufferTime ? 'hidden' : 'visible';

--- a/js/scenes/gameover.js
+++ b/js/scenes/gameover.js
@@ -1,6 +1,6 @@
 import { saveScoreAndGetQR } from '../qrLogic.js';
 
-const RANKS = ['1ST', '2ND', '3RD', '4TH', '5TH'];
+const RANKS = ['1ST', '2ND', '3RD', '4TH', '5TH', '6TH'];
 let rendered = false;
 let sessionScores = [];
 

--- a/js/scenes/gameplay.js
+++ b/js/scenes/gameplay.js
@@ -42,6 +42,11 @@ export function createGame(particlesEl, overlayEl, xMin, xMax) {
         lastMatchTime   = 0;
         matchedGestures = [];
         spawnTarget();
+
+        const scoreEl = document.createElement('p');
+        scoreEl.className = 'scene-text scene-text--game-score';
+        scoreEl.textContent = 'Score: 0';
+        overlayEl.appendChild(scoreEl);
     }
 
     // Called every frame. Checks for a gesture match and returns the current

--- a/style.css
+++ b/style.css
@@ -210,13 +210,13 @@ body {
 
 .scene-text--game-score {
     font-size: clamp(20px, 2.5vw, 30px);
-    top: auto;
-    bottom: 4%;
-    left: 20px;
-    transform: none;
-    text-align: left;
+    top: 4%;
+    bottom: auto;
+    left: 50%;
+    transform: translateX(-50%);
+    text-align: center;
     animation: scorePop 0.2s ease-out;
-    background: #F4F4F4;
+    background: #c9c3c3;
     border: 2px solid var(--color-almost-black);
     padding: 6px 16px;
     font-weight: 700;
@@ -224,16 +224,16 @@ body {
     text-shadow: none;
 }
 
-.multipplpayer #overlay-p1 .scene-text--game-score {
-    left: 10px;
+.multiplayer #overlay-p1 .scene-text--game-score {
+    left: 25%;
 }
 .multiplayer #overlay-p2 .scene-text--game-score {
-    left: 50%;
+    left: 75%;
 }
 
 @keyframes scorePop {
-    0%   { transform: scale(1.4); }
-    100% { transform: scale(1); }
+    0%   { transform: translateX(-50%) scale(1.4); }
+    100% { transform: translateX(-50%) scale(1); }
 }
 
 .timebar {


### PR DESCRIPTION
1. Put on player_rank 6
2. Ignore inputs for first 5 seconds to prevent accidental skips
3. Removed logo from startscreen
4. Score on top of screen